### PR TITLE
Cleanup wslink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist
 server/www
 Pipfile
 build/glance-vessels/
+__pycache__

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "wslink"]
-	path = wslink
-	url = https://github.com/Kitware/wslink.git
-	branch = master

--- a/README.md
+++ b/README.md
@@ -33,8 +33,6 @@ This has only been tested with python3.
 ```
 $ git clone git@github.com:KitwareMedical/glance-vessels.git
 $ cd glance-vessels/
-$ git submodule init
-$ git submodule update
 $ npm install
 $ npm run build:release
 $ cd server/

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -14,11 +14,6 @@ jobs:
 
   steps:
   - script: |
-      git submodule init
-      git submodule update
-    displayName: 'Download Git submodules'
-
-  - script: |
       sudo apt-get update
       sudo apt-get install -y python3 python3-dev python3-pip python3-venv
     displayName: 'Install OS packages'
@@ -57,11 +52,6 @@ jobs:
     vmImage: 'macos-10.13'
 
   steps:
-  - script: |
-      git submodule init
-      git submodule update
-    displayName: 'Download Git submodules'
-
   - task: UsePythonVersion@0
     inputs:
       versionSpec: '3.5'
@@ -101,11 +91,6 @@ jobs:
     vmImage: 'vs2017-win2016'
 
   steps:
-  - script: |
-      git submodule init
-      git submodule update
-    displayName: 'Download Git submodules'
-
   - task: UsePythonVersion@0
     inputs:
       versionSpec: '3.7'

--- a/package-lock.json
+++ b/package-lock.json
@@ -18589,6 +18589,12 @@
               "dev": true
             }
           }
+        },
+        "vuetify": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-1.5.2.tgz",
+          "integrity": "sha512-OzXHXklOpfYufV1l8v/av99gty6osJ/acTKqd/4CsRPOW+eyJA4nABXWk+4Qm9eAF/Uuf/fSHOprv4donvTeLw==",
+          "dev": true
         }
       }
     },
@@ -24783,6 +24789,11 @@
       "requires": {
         "async-limiter": "~1.0.0"
       }
+    },
+    "wslink": {
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/wslink/-/wslink-0.1.11.tgz",
+      "integrity": "sha512-TW4YGnuI298oG9Dcij4lHLwbVz5KcJsnzvHznMKAJAFJpV78M3dz/038/fGlZ+HjyOp+Kao4g69X8kpXuWMOTA=="
     },
     "xmlbuilder": {
       "version": "9.0.7",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
     "vuetify": "1.5.14",
     "vuex": "^3.0.1",
     "webworker-promise": "0.4.1",
-    "workbox-sw": "2.1.2"
+    "workbox-sw": "2.1.2",
+    "wslink": "^0.1.11"
   },
   "devDependencies": {
     "@babel/plugin-syntax-dynamic-import": "7.0.0",

--- a/src/remote.js
+++ b/src/remote.js
@@ -1,4 +1,4 @@
-import WebsocketConnection from 'paraview-glance/wslink/js/src/WebsocketConnection';
+import WebsocketConnection from 'wslink/src/WebsocketConnection';
 
 import * as serializable from 'paraview-glance/src/serializable';
 // register transformers


### PR DESCRIPTION
Remove the wslink submodule in favor of the updated npm module. This will simplify the setup instructions.